### PR TITLE
Convert regex to raw strings, fix locale.format deprecation for py3.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 *.pyc
+*.egg-info
+__pycache__/
+dist/
+test_files/media/*.avi

--- a/awescript/awescript.py
+++ b/awescript/awescript.py
@@ -156,7 +156,7 @@ def get_files(path, cwdsolo, options):
         for d in dirs:
             path = base + d + os.sep
             # fix paths with [ or ] in name
-            path = re.sub("([[\\]])", "[\\1]", path) + "*.*"
+            path = re.sub(r"([[\\]])", "[\\1]", path) + "*.*"
             if options.debug:
                 print("glob.glob " + path)
             fileList += glob.glob(path)
@@ -164,7 +164,7 @@ def get_files(path, cwdsolo, options):
 
     # move sfv files to top of list
     for sfv_file in fileList:
-        if re.search("\.sfv$", sfv_file, re.IGNORECASE):
+        if re.search(r"\.sfv$", sfv_file, re.IGNORECASE):
             sfvList.append(sfv_file)
             fileList.remove(sfv_file)
 
@@ -186,17 +186,17 @@ def get_files(path, cwdsolo, options):
         if folder:
             folder += os.sep
 
-        if not re.search("\.(avi|mkv|m4v|mp4|wmv|ts|divx|ogm|mpg|mpeg|part0?0?1\.rar|00[0-1]|vob|m2ts|sfv|srs|srr|nfo|jpg)$", filename, re.IGNORECASE):
-            if (not (re.search("\.rar$", filename, re.IGNORECASE) and
-                     not re.search("\.part\d{2,3}\.rar$", filename, re.IGNORECASE))):
+        if not re.search(r"\.(avi|mkv|m4v|mp4|wmv|ts|divx|ogm|mpg|mpeg|part0?0?1\.rar|00[0-1]|vob|m2ts|sfv|srs|srr|nfo|jpg)$", filename, re.IGNORECASE):
+            if (not (re.search(r"\.rar$", filename, re.IGNORECASE) and
+                     not re.search(r"\.part\d{2,3}\.rar$", filename, re.IGNORECASE))):
                 continue
-            if re.search("\.part[2-9]\.rar$", filename, re.IGNORECASE):
+            if re.search(r"\.part[2-9]\.rar$", filename, re.IGNORECASE):
                 basename = filename.split(".rar", 1)[0]
                 if not os.path.exists(folder + basename + ".r00"):
                     continue
 
         # SFV Detection
-        if re.search("\.sfv$", filename, re.IGNORECASE):
+        if re.search(r"\.sfv$", filename, re.IGNORECASE):
             sfv = filename
             missingList = []
             for line in fileinput.input([folder + filename]):
@@ -207,7 +207,7 @@ def get_files(path, cwdsolo, options):
 
                     if not os.path.exists(folder + str(f)):
                         skip = True
-                        if re.search("\.(rar|[rstu0-9][0-9][0-9])$", f, re.IGNORECASE):
+                        if re.search(r"\.(rar|[rstu0-9][0-9][0-9])$", f, re.IGNORECASE):
                             if not options.rename_wrong_case or not os.path.exists(folder + str(f).lower()):
                                 missingList.append(f)
                             else:
@@ -219,22 +219,22 @@ def get_files(path, cwdsolo, options):
                         if skip:
                             continue
 
-                    if (re.search("\.part0?0?1\.rar$", f, re.IGNORECASE) or
-                        (re.search("\.(rar|00[0-1])$", f, re.IGNORECASE) and
-                         not re.search("\.part\d{1,3}\.rar$", f, re.IGNORECASE))):
+                    if (re.search(r"\.part0?0?1\.rar$", f, re.IGNORECASE) or
+                        (re.search(r"\.(rar|00[0-1])$", f, re.IGNORECASE) and
+                         not re.search(r"\.part\d{1,3}\.rar$", f, re.IGNORECASE))):
                         if main_file:
                             blackList.append(f)
                         else:
                             main_file = f
                         main_files.append(f)
-                    elif re.search("\.part[2-9]\.rar$", f, re.IGNORECASE):
+                    elif re.search(r"\.part[2-9]\.rar$", f, re.IGNORECASE):
                         if os.path.exists(folder + f.split(".rar", 1)[0] + ".r00"):
                             if main_file:
                                 blackList.append(f)
                             else:
                                 main_file = f
                             main_files.append(f)
-                    if re.search("\.(rar|[rstu0-9][0-9][0-9])$", f, re.IGNORECASE):
+                    if re.search(r"\.(rar|[rstu0-9][0-9][0-9])$", f, re.IGNORECASE):
                         fset.append(f)
             #
             # multi-rar sets subs fix
@@ -247,15 +247,15 @@ def get_files(path, cwdsolo, options):
                 cont = False
                 print("Files missing from " + filename + ":\n " + str(missingList))  # str(missingList) +
                 for miss in missingList:
-                    if re.search("\.(avi|divx|mkv|m4v|mp4|wmv|ts|ogm|mpg|mpeg)$", miss, re.IGNORECASE):
+                    if re.search(r"\.(avi|divx|mkv|m4v|mp4|wmv|ts|ogm|mpg|mpeg)$", miss, re.IGNORECASE):
                         print("SFV contains missing video file.  Skipping instead of quitting.")
                         cont = True
                         break
-                    elif re.search("\.(nfo|par2)$", miss, re.IGNORECASE):
+                    elif re.search(r"\.(nfo|par2)$", miss, re.IGNORECASE):
                         print("SFV contains MISC files.  Non-Scene SFV.")
                         cont = True
                         break
-                    elif re.search("(sub.*|-s)\.rar", miss, re.IGNORECASE) and len(missingList) <= 2:
+                    elif re.search(r"(sub.*|-s)\.rar", miss, re.IGNORECASE) and len(missingList) <= 2:
                         print("Subs files from SFV missing.")
                         cont = True
                         break
@@ -271,7 +271,7 @@ def get_files(path, cwdsolo, options):
             main_file = filename
 
         # Look inside RAR and get types (i.e. AVI,MKV,SUBS)
-        if re.search("\.(rar|00[0-1])$", main_file, re.IGNORECASE):
+        if re.search(r"\.(rar|00[0-1])$", main_file, re.IGNORECASE):
             if blackList.count(main_file):
                 continue
             if os.path.exists(folder + main_file.split(".001", 1)[0] + ".000"):
@@ -300,23 +300,23 @@ def get_files(path, cwdsolo, options):
                     return []
                 else:  # since last 2 aren't same size, we must have last rar to check for missing!
                     numRARs = 0
-                    if re.search("\.part(\d{1,3})\.rar$", fset[len(fset) - 1], re.IGNORECASE):
-                        numRARs = int(re.search("\.part(\d{1,3})\.rar$", fset[len(fset) - 1], re.IGNORECASE).groups()[0])
-                    elif re.search("\.u(\d{2})$", fset[len(fset) - 1], re.IGNORECASE):
-                        numRARs = int(re.search("\.u(\d{2})$", fset[len(fset) - 1], re.IGNORECASE).groups()[0])
+                    if re.search(r"\.part(\d{1,3})\.rar$", fset[len(fset) - 1], re.IGNORECASE):
+                        numRARs = int(re.search(r"\.part(\d{1,3})\.rar$", fset[len(fset) - 1], re.IGNORECASE).groups()[0])
+                    elif re.search(r"\.u(\d{2})$", fset[len(fset) - 1], re.IGNORECASE):
+                        numRARs = int(re.search(r"\.u(\d{2})$", fset[len(fset) - 1], re.IGNORECASE).groups()[0])
                         numRARs += 302
-                    elif re.search("\.t(\d{2})$", fset[len(fset) - 1], re.IGNORECASE):
-                        numRARs = int(re.search("\.t(\d{2})$", fset[len(fset) - 1], re.IGNORECASE).groups()[0])
+                    elif re.search(r"\.t(\d{2})$", fset[len(fset) - 1], re.IGNORECASE):
+                        numRARs = int(re.search(r"\.t(\d{2})$", fset[len(fset) - 1], re.IGNORECASE).groups()[0])
                         numRARs += 202
-                    elif re.search("\.s(\d{2})$", fset[len(fset) - 1], re.IGNORECASE):
-                        numRARs = int(re.search("\.s(\d{2})$", fset[len(fset) - 1], re.IGNORECASE).groups()[0])
+                    elif re.search(r"\.s(\d{2})$", fset[len(fset) - 1], re.IGNORECASE):
+                        numRARs = int(re.search(r"\.s(\d{2})$", fset[len(fset) - 1], re.IGNORECASE).groups()[0])
                         numRARs += 102
-                    elif re.search("\.r(\d{2})$", fset[len(fset) - 2], re.IGNORECASE):
-                        numRARs = int(re.search("\.r(\d{2})$", fset[len(fset) - 2], re.IGNORECASE).groups()[0])
+                    elif re.search(r"\.r(\d{2})$", fset[len(fset) - 2], re.IGNORECASE):
+                        numRARs = int(re.search(r"\.r(\d{2})$", fset[len(fset) - 2], re.IGNORECASE).groups()[0])
                         numRARs += 2
-                    elif re.search("\.(\d{3})$", fset[len(fset) - 1], re.IGNORECASE):
-                        numRARs = int(re.search("\.(\d{3})$", fset[len(fset) - 1], re.IGNORECASE).groups()[0])
-                        if re.search("\.(rar|000)$", main_file, re.IGNORECASE):
+                    elif re.search(r"\.(\d{3})$", fset[len(fset) - 1], re.IGNORECASE):
+                        numRARs = int(re.search(r"\.(\d{3})$", fset[len(fset) - 1], re.IGNORECASE).groups()[0])
+                        if re.search(r"\.(rar|000)$", main_file, re.IGNORECASE):
                             numRARs += 1
                     # else: return []
 
@@ -345,7 +345,7 @@ def get_files(path, cwdsolo, options):
                 std = std.replace("\\r", "")
                 std = std.replace("\r", "")
                 output = std.split("\n")
-            elif len(output) == 0 and re.search("\.(avi|divx|mkv|m4v|mp4|ts|ogm|mpg|mpeg|)\.00[0-1]$", main_file, re.IGNORECASE):
+            elif len(output) == 0 and re.search(r"\.(avi|divx|mkv|m4v|mp4|ts|ogm|mpg|mpeg|)\.00[0-1]$", main_file, re.IGNORECASE):
                 # if os.path.exists(folder + main_file.split(".001",1)[0] + ".000"):
                 #    main_file = main_file.split(".001",1)[0] + ".000"
                 print("%s is a joined file." % main_file)
@@ -357,9 +357,9 @@ def get_files(path, cwdsolo, options):
                 print("%s could be corrupt?" % main_file)
                 continue
 
-            if re.search("extra", main_file, re.IGNORECASE):
+            if re.search(r"extra", main_file, re.IGNORECASE):
                 subtyp = "Extras"
-                if not re.search("extra", cwdsolo, re.IGNORECASE):
+                if not re.search(r"extra", cwdsolo, re.IGNORECASE):
                     dest = "Extras" + os.sep
 
             #
@@ -368,11 +368,11 @@ def get_files(path, cwdsolo, options):
             for s in output:  # could be multiple files in the rar
                 if not s:
                     continue  # for blanks at the end from splitting \r\n or \n
-                if re.search("\.(avi|divx|mkv|m4v|mp4|wmv|ts|ogm|mka|dts|ac3|mpg|mpeg|mp3|ogg)$", s, re.IGNORECASE):
+                if re.search(r"\.(avi|divx|mkv|m4v|mp4|wmv|ts|ogm|mka|dts|ac3|mpg|mpeg|mp3|ogg)$", s, re.IGNORECASE):
                     typ = "Video"
                     if not folder:
                         sets_in_main += 1  # i.e. not in CD[1-9], so may need to move
-                elif re.search("\.(iso|img|nrg|bin|gcm|cdi|dvd|gi)$", s, re.IGNORECASE):
+                elif re.search(r"\.(iso|img|nrg|bin|gcm|cdi|dvd|gi)$", s, re.IGNORECASE):
                     typ = "ISO"
                     subtyp = "Compressed"
                 else:
@@ -383,8 +383,8 @@ def get_files(path, cwdsolo, options):
                 for s in output:  # could be multiple files in the rar
                     if not s:
                         continue  # for blanks at the end from splitting \r\n or \n
-                    if re.search("\.(srt|sub|idx|rar)$", s, re.IGNORECASE):
-                        if re.search("vob.?sub", main_file, re.IGNORECASE):
+                    if re.search(r"\.(srt|sub|idx|rar)$", s, re.IGNORECASE):
+                        if re.search(r"vob.?sub", main_file, re.IGNORECASE):
                             typ = "VobSubs"
                             if not folder:
                                 dest = "VobSubs" + os.sep
@@ -392,7 +392,7 @@ def get_files(path, cwdsolo, options):
                             typ = "Subs"
                             if not folder:
                                 dest = "Subs" + os.sep
-                        if subtyp == "Extras" and not re.search("extra", cwdsolo, re.IGNORECASE):
+                        if subtyp == "Extras" and not re.search(r"extra", cwdsolo, re.IGNORECASE):
                             if not folder:
                                 dest = "Extras" + os.sep + dest
                         break
@@ -401,17 +401,17 @@ def get_files(path, cwdsolo, options):
 
         # Check for Video files NOT in RAR files
         # i.e. samples or previously extracted video
-        elif re.search("\.(avi|mkv|m4v|mp4|wmv|ts|vob|m2ts|mpg|mpeg)$", main_file, re.IGNORECASE):
+        elif re.search(r"\.(avi|mkv|m4v|mp4|wmv|ts|vob|m2ts|mpg|mpeg)$", main_file, re.IGNORECASE):
 
-            if re.search("extra", folder + main_file, re.IGNORECASE):
+            if re.search(r"extra", folder + main_file, re.IGNORECASE):
                 subtyp = "Extras"
             # check if sample
-            if re.search("sample", folder, re.IGNORECASE) or is_sample(folder + main_file, subtyp):
-                if re.search("\.vob$", main_file, re.IGNORECASE):
+            if re.search(r"sample", folder, re.IGNORECASE) or is_sample(folder + main_file, subtyp):
+                if re.search(r"\.vob$", main_file, re.IGNORECASE):
                     typ = "VobSample"
                     if not folder:
                         dest = "Sample" + os.sep
-                elif re.search("\.m2ts$", main_file, re.IGNORECASE):
+                elif re.search(r"\.m2ts$", main_file, re.IGNORECASE):
                     typ = "m2tsSample"
                     if not folder:
                         dest = "Sample" + os.sep
@@ -419,7 +419,7 @@ def get_files(path, cwdsolo, options):
                     typ = "Sample"
                     if not folder:
                         dest = "Sample" + os.sep
-                if subtyp == "Extras" and not re.search("extra", cwdsolo, re.IGNORECASE):
+                if subtyp == "Extras" and not re.search(r"extra", cwdsolo, re.IGNORECASE):
                     if not folder:
                         dest = "Extras" + os.sep + dest
             else:
@@ -433,20 +433,20 @@ def get_files(path, cwdsolo, options):
                     sets_in_main += 1  # i.e. not in CD[1-9], so may need to move
                 # continue
 
-        elif re.search("\.nfo$", main_file, re.IGNORECASE):
+        elif re.search(r"\.nfo$", main_file, re.IGNORECASE):
             typ = "Other"
             subtyp = "NFO"
             if not folder:
                 dest = options.nfos_dir + os.sep
 
-        elif re.search(".*proof.*\.jpg$", main_file, re.IGNORECASE):
+        elif re.search(r".*proof.*\.jpg$", main_file, re.IGNORECASE):
             typ = "Proof"
             subtyp = ""
             if not folder:
                 dest = "Proof" + os.sep
 
-        elif re.search("\.srs$", main_file, re.IGNORECASE):
-            if re.search("extra", main_file, re.IGNORECASE):
+        elif re.search(r"\.srs$", main_file, re.IGNORECASE):
+            if re.search(r"extra", main_file, re.IGNORECASE):
                 subtyp = "Extras_SRS"
                 if not folder:
                     dest = "Extras" + os.sep + "Sample" + os.sep
@@ -456,7 +456,7 @@ def get_files(path, cwdsolo, options):
                     dest = "Sample" + os.sep
             typ = "Sample"
 
-        elif re.search("\.srr$", main_file, re.IGNORECASE):
+        elif re.search(r"\.srr$", main_file, re.IGNORECASE):
             typ = "Other"
             subtyp = "SRR"
 
@@ -467,7 +467,7 @@ def get_files(path, cwdsolo, options):
         fileMainList.append([folder, main_file, sfv, fset, typ, subtyp, dest, sr_dir])
 
     # Detect CD folders - skip if folder has TV tags
-    if sets_in_main >= 2 and not re.search("([\._\s]s?\d{1,3}[\._\s]?[ex]\d{1,3}|s\d{1,3})", cwdsolo, re.IGNORECASE):  # 2 or more CDs possible
+    if sets_in_main >= 2 and not re.search(r"([\._\s]s?\d{1,3}[\._\s]?[ex]\d{1,3}|s\d{1,3})", cwdsolo, re.IGNORECASE):  # 2 or more CDs possible
         fileMainList = get_cds(fileMainList)
 
     return fileMainList
@@ -475,14 +475,14 @@ def get_files(path, cwdsolo, options):
 
 def is_sample(video, subtyp):
     max_size = 50000000
-    if re.search("\.(mkv|m4v|mp4|ts)$", video, re.IGNORECASE):
+    if re.search(r"\.(mkv|m4v|mp4|ts)$", video, re.IGNORECASE):
         max_size = 250000000
 
-    if re.search("^.*?([\.\-_\w]?sa?mp).*?\.(?:avi|mkv|m4v|mp4|wmv|vob|m2ts|ts|mpg|mpeg)$", video, re.IGNORECASE):
+    if re.search(r"^.*?([\.\-_\w]?sa?mp).*?\.(?:avi|mkv|m4v|mp4|wmv|vob|m2ts|ts|mpg|mpeg)$", video, re.IGNORECASE):
         if os.path.getsize(video) < max_size: return True
     # TODO: add check to make sure not extras before doing this
     else:  # no s?mp in filename - reduce filesize limits manually
-        if subtyp != "Extras" and re.search("\.(avi|mkv|m4v|mp4|wmv|vob|m2ts|ts|mpg|mpeg)$", video, re.IGNORECASE) and os.path.getsize(video) < max_size / 2:
+        if subtyp != "Extras" and re.search(r"\.(avi|mkv|m4v|mp4|wmv|vob|m2ts|ts|mpg|mpeg)$", video, re.IGNORECASE) and os.path.getsize(video) < max_size / 2:
             return True
 
     return False
@@ -510,14 +510,14 @@ def get_cds(fileMainList):
         file = fileList[i][1]
         posTemp = 0
 
-        if re.search("(s\d{1,3}[\._]?e\d{1,3})", file, re.IGNORECASE):
+        if re.search(r"(s\d{1,3}[\._]?e\d{1,3})", file, re.IGNORECASE):
             continue  # TV Test (file) - MAKE THIS FOR DIR
         for j in range(len(fileList)):
             if i == j: continue  # i <= j ?  since they've already been compared once?
             if fileList[j][4] != "Video":
                 continue
             file2 = fileList[j][1]
-            if re.search("(s\d{1,3}[\._]?e\d{1,3})", file2, re.IGNORECASE):
+            if re.search(r"(s\d{1,3}[\._]?e\d{1,3})", file2, re.IGNORECASE):
                 continue  # TV Test (file2)
             if len(file) == len(file2):
                 diff = 0
@@ -549,9 +549,9 @@ def get_cds(fileMainList):
     for i in fileListNew:
         file = fileMainList[i][1]
         char = file[position]
-        if re.match("^([1-9])$", char):
+        if re.match(r"^([1-9])$", char):
             cd = char
-        elif re.match("^([A-Ia-i])$", char):
+        elif re.match(r"^([A-Ia-i])$", char):
             if char == "a": cd = "1"
             elif char == "b": cd = "2"
             elif char == "c": cd = "3"
@@ -567,7 +567,7 @@ def get_cds(fileMainList):
 
         if char == "e" and len(fileListNew) <= 4:  # no CD4 so most likely Extras
             print(file + " is Extras")
-            if re.search("\.(rar|00[0-1])$", file, re.IGNORECASE):
+            if re.search(r"\.(rar|00[0-1])$", file, re.IGNORECASE):
                 fileMainList[i][5] = "Extras"
             else:
                 fileMainList[i][5] = "Extracted_Extras"
@@ -585,7 +585,7 @@ def get_cds(fileMainList):
 
         # get/make directory
         fileMainList[i][6] = "CD" + cd + os.sep
-        if re.search("\.(rar|00[0-1])$", file, re.IGNORECASE):
+        if re.search(r"\.(rar|00[0-1])$", file, re.IGNORECASE):
             fileMainList[i][5] = "CD"
         else:
             fileMainList[i][5] = "Extracted_CD"
@@ -600,26 +600,26 @@ def wildc(folder, file):
 
     basename = False
     wildcard = False
-    if re.search("\.(part01\.rar)$", file, re.IGNORECASE):
-        ext = re.search("\.(part01\.rar)$", file, re.IGNORECASE).groups()[0]
+    if re.search(r"\.(part01\.rar)$", file, re.IGNORECASE):
+        ext = re.search(r"\.(part01\.rar)$", file, re.IGNORECASE).groups()[0]
         wildcard = ".[Pp][Aa][Rr][Tt][0-9][0-9].[Rr][Aa][Rr]"
-    elif re.search("\.(part001\.rar)$", file, re.IGNORECASE):
-        ext = re.search("\.(part001\.rar)$", file, re.IGNORECASE).groups()[0]
+    elif re.search(r"\.(part001\.rar)$", file, re.IGNORECASE):
+        ext = re.search(r"\.(part001\.rar)$", file, re.IGNORECASE).groups()[0]
         wildcard = ".[Pp][Aa][Rr][Tt][0-9][0-9][0-9].[Rr][Aa][Rr]"
-    elif re.search("\.(rar)$", file, re.IGNORECASE):
-        if re.search("\.(part1\.rar)$", file, re.IGNORECASE):
+    elif re.search(r"\.(rar)$", file, re.IGNORECASE):
+        if re.search(r"\.(part1\.rar)$", file, re.IGNORECASE):
             filename = folder + file.split(".rar", 1)[0] + ".r00".replace("[", "[[]")
             if os.path.exists(filename):
-                ext = re.search("\.(part1\.rar)$", file, re.IGNORECASE).groups()[0]
+                ext = re.search(r"\.(part1\.rar)$", file, re.IGNORECASE).groups()[0]
                 wildcard = ".[Pp][Aa][Rr][Tt]1.[Rr]??"
             else:
-                ext = re.search("\.(part1\.rar)$", file, re.IGNORECASE).groups()[0]
+                ext = re.search(r"\.(part1\.rar)$", file, re.IGNORECASE).groups()[0]
                 wildcard = ".[Pp][Aa][Rr][Tt][0-9].[Rr][Aa][Rr]"
         else:
-            ext = re.search("\.(rar)$", file, re.IGNORECASE).groups()[0]
+            ext = re.search(r"\.(rar)$", file, re.IGNORECASE).groups()[0]
             wildcard = ".[Rr]??"
-    elif re.search(".(00[0-1])$", file, re.IGNORECASE):
-        ext = re.search("\.(00[0-1])$", file, re.IGNORECASE).groups()[0]
+    elif re.search(r".(00[0-1])$", file, re.IGNORECASE):
+        ext = re.search(r"\.(00[0-1])$", file, re.IGNORECASE).groups()[0]
         wildcard = ".[0-9][0-9][0-9]"
     else: return False
 
@@ -1131,13 +1131,13 @@ def main(options, path):
             print("PAR2 files exist.  Exiting...")
             sys.exit()
 
-    if re.search("(subpack|sub.?fix|subs\.)", cwdsolo, re.IGNORECASE):
+    if re.search(r"(subpack|sub.?fix|subs\.)", cwdsolo, re.IGNORECASE):
         print("SUBS directory detected.  Not processing.")
         return
-    elif re.search("(sync.?fix)", cwdsolo, re.IGNORECASE):
+    elif re.search(r"(sync.?fix)", cwdsolo, re.IGNORECASE):
         print("SYNCFiX directory detected.  Not processing.")
         return
-    elif re.search("(sample.?fix)", cwdsolo, re.IGNORECASE):
+    elif re.search(r"(sample.?fix)", cwdsolo, re.IGNORECASE):
         print("SAMPLEFiX directory detected.  Not processing.")
         return
 
@@ -1282,17 +1282,17 @@ if __name__ == '__main__':
                 if current in root:
                     continue
                 for mfile in files:
-                    if re.search("\.(rar|00[0-1]|avi|mkv|m4v|mp4|wmv|ts|ogm|divx|mpg|mpeg)$", mfile):
+                    if re.search(r"\.(rar|00[0-1]|avi|mkv|m4v|mp4|wmv|ts|ogm|divx|mpg|mpeg)$", mfile):
                         found = True
                         break
                 if not found:
                     for directory in dirs:
-                        if re.match("^cd[1-9]$", directory, re.IGNORECASE):
+                        if re.match(r"^cd[1-9]$", directory, re.IGNORECASE):
                             found = True
                             break
                 if found:
                     current = root
                     main(options, root)
-                    os.chdir(origcwd)
+                    os.chdir(globals()["origcwd"])
 
             print("\n\n\nDone with %s directory.\n\n" % path)

--- a/bin/preprardir.py
+++ b/bin/preprardir.py
@@ -211,18 +211,18 @@ class VersionTag(object):
 def versiontag(file_name):
 	"""Returns version tag object."""
 	# Windows
-	match = re.match("[a-zA-Z]+(?P<x64>-x64-)?"
-					 "(?P<large>\d)(?P<small>\d\d?)"
-					 "(?P<beta>b\d)?.+", file_name)
+	match = re.match(r"[a-zA-Z]+(?P<x64>-x64-)?"
+					 r"(?P<large>\d)(?P<small>\d\d?)"
+					 r"(?P<beta>b\d)?.+", file_name)
 	if match:
 		x64, large, small, beta = match.group("x64", "large", "small", "beta")
 		if len(small) == 1:
 			small += "0"
 		return VersionTag(large, small, beta, x64)
 	# Linux, OS X, BSD
-	match = re.match("rar(osx|linux|bsd)-(?P<x64>x64-)?"
-					 "(?P<large>\d)\.(?P<small>\d(\.\d)?)\.?"
-					 "(?P<beta>b\d)?\.tar.gz", file_name)
+	match = re.match(r"rar(osx|linux|bsd)-(?P<x64>x64-)?"
+					 r"(?P<large>\d)\.(?P<small>\d(\.\d)?)\.?"
+					 r"(?P<beta>b\d)?\.tar.gz", file_name)
 	if match:
 		x64, large, small, beta = match.group("x64", "large", "small", "beta")
 		if len(small) == 1:

--- a/bin/pyrescene.py
+++ b/bin/pyrescene.py
@@ -24,7 +24,7 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-"""
+r"""
 This tool creates an SRR file from a release directory.
 
 design decisions:
@@ -459,7 +459,7 @@ def remove_unwanted_sfvs(sfv_list, release_dir):
 		#     tdk-subs-done.sfv
 		if ("subs" in sfv_name.lower() and
 			# music or release with multiple CDs (xvid)
-			(re.match("^000?-|.*(cd\d|flac).*", sfv_name, re.IGNORECASE) or
+			(re.match(r"^000?-|.*(cd\d|flac).*", sfv_name, re.IGNORECASE) or
 				"subs" in lcrelease_name or
 				"subpack" in lcrelease_name or
 				"vobsub" in lcrelease_name or
@@ -515,7 +515,7 @@ def remove_unwanted_sfvs(sfv_list, release_dir):
 					logging.warning(msg.format(rar))
 					continue
 
-		if re.match(".*Subs.?CD\d$", os.path.dirname(sfv), re.IGNORECASE):
+		if re.match(r".*Subs.?CD\d$", os.path.dirname(sfv), re.IGNORECASE):
 			# Toy.Story.1995.DVDRip.DivX.AC3.iNTERNAL-FFM/
 			# 	Subs/CD1/toyst.subs.cd1-iffm.sfv
 			# The.Postman.1997.DVDRip.XviD.AC3.iNTERNAL-FFM
@@ -650,11 +650,11 @@ def is_storable_fix(release_name):
 	# Ron.White.You.Cant.Fix.Stupid.XviD-LMG
 	# not: Rar|sub|audio|sample|
 	return (re.match(
-			".*(SFV|PPF|sync|proof?|dir|nfo|Interleaving|Trackorder).?"
-			"(Fix|Patch).*", release_name, re.IGNORECASE) or
-			re.match(".*\.(FiX|FIX)(\.|-).*", release_name) or
-			re.match(".*\.DVDR.Fix-.*", release_name) or
-			re.match(".*\.DVDR.REPACK.Fix-.*", release_name))
+			r".*(SFV|PPF|sync|proof?|dir|nfo|Interleaving|Trackorder).?"
+			r"(Fix|Patch).*", release_name, re.IGNORECASE) or
+			re.match(r".*\.(FiX|FIX)(\.|-).*", release_name) or
+			re.match(r".*\.DVDR.Fix-.*", release_name) or
+			re.match(r".*\.DVDR.REPACK.Fix-.*", release_name))
 
 def create_srr_for_subs(unrar, sfv, working_dir, release_dir):
 	"""
@@ -1345,7 +1345,7 @@ def is_release(dirpath, dirnames=None, filenames=None):
 			elif NO_HYPHEN.match(dirname):
 				# old MP3 release with custom folders
 				custom_dirs_old_music.append(dirname)
-			elif re.match("CD(.?|_-_)\d{1-2}.+", dirname, re.IGNORECASE):
+			elif re.match(r"CD(.?|_-_)\d{1-2}.+", dirname, re.IGNORECASE):
 				# Various_artists_-_deiner_tracks_vol2_2cd-2000-nbd
 				# CD1-Dj_Membrain and CD2-Dj_Sepalot
 				custom_dirs_old_music.append(dirname)
@@ -1501,7 +1501,7 @@ def main(argv=None):
 	                  help="regex to skip files files to store. matched to "
 	                  "the path inside the release dir. "
 	                  "use ^ and $ to match whole path. "
-	                  "e.g. ^.*/sitename\.nfo$ (case ignored)")
+	                  r"e.g. ^.*/sitename\.nfo$ (case ignored)")
 
 	# speedup rerun, less traffic, backup textfiles, ...
 	parser.add_option("--no-srs", action="store_true", dest="nosrs",
@@ -1689,15 +1689,15 @@ def main(argv=None):
 		global skipre
 		try:
 			skipre = re.compile(options.skip_regex, re.IGNORECASE)
-			if skipre.match("test.sfv"):
+			if skipre.match(r"test.sfv"):
 				msg = "Not a good idea to ignore SFV files in the regex!"
 				logging.warning(msg)
 		except Exception as e:
 			# use --skip-regex "*" to trigger this
 			print("Unrecognized regular expression: %s" % e)
 			print("Some examples: (case always ignored)")
-			print("\t^.*/sitename\.nfo$")
-			print("\t^sample/.*\._s.jpg$")
+			print(r"\t^.*/sitename\.nfo$")
+			print(r"\t^sample/.*\._s.jpg$")
 			return 1  # failure
 
 	drive_letters = []

--- a/dev-docs/extlibs/rar_hachoir.py
+++ b/dev-docs/extlibs/rar_hachoir.py
@@ -68,6 +68,11 @@ DICTIONARY_SIZE = {
     7: "File is a directory",
 }
 
+# compatibility with 2.x
+import sys
+if sys.hexversion < 0x3000000:
+    range = xrange  # @ReservedAssignment
+
 def formatRARVersion(field):
     """
     Decodes the RAR version stored on 1 byte

--- a/dev-docs/extlibs/rarfile.py
+++ b/dev-docs/extlibs/rarfile.py
@@ -94,7 +94,7 @@ except ImportError:
 # compat with 2.x
 if sys.hexversion < 0x3000000:
     # prefer 3.x behaviour
-    range = xrange
+    range = xrange #@ReservedAssignment
     # py2.6 has broken bytes()
     def bytes(s, enc):
         return str(s)

--- a/rerar/rarfile.py
+++ b/rerar/rarfile.py
@@ -104,7 +104,7 @@ except ImportError:
 # compat with 2.x
 if sys.hexversion < 0x3000000:
     # prefer 3.x behaviour
-    range = xrange
+    range = xrange #@ReservedAssignment
     # py2.6 has broken bytes()
     def bytes(s, enc):
         return str(s)

--- a/resample/main.py
+++ b/resample/main.py
@@ -983,7 +983,7 @@ def avi_profile_sample(self, avi_data):  # FileData object
 	return tracks, attachments
 
 def mkv_profile_sample(self, mkv_data):  # FileData object
-	"""
+	r"""
 	* EBML Header [header|content]  \__full file size
 	* Segment     [header|content]  /
 		- 

--- a/resample/test/test_mp3.py
+++ b/resample/test/test_mp3.py
@@ -101,7 +101,7 @@ class TestDoubleId3v2(unittest.TestCase):
 		self.assertEqual(10, offset)
 
 	def test_last_id3v2_before_sync_one(self):
-		"""\xFF\xFF will match."""
+		r"""\xFF\xFF will match."""
 		self.mp3stream.write(b"\xFF\xFF\xE0\x33\x44")
 		offset = mp3.last_id3v2_before_sync(self.mp3stream, 35)
 		self.assertEqual(10, offset)

--- a/rescene/main.py
+++ b/rescene/main.py
@@ -1782,9 +1782,9 @@ class RarExecutable(object):
 		self.args = None
 		
 		# parse file name
-		match = re.match("(?P<date>\d{4}-\d{2}-\d{2})_rar"
-		                 "(?P<major>\d)(?P<minor>\d\d)"
-		                 "(?P<beta>b\d)?(\.exe)?", rar_sfx_file)
+		match = re.match(r"(?P<date>\d{4}-\d{2}-\d{2})_rar"
+		                 r"(?P<major>\d)(?P<minor>\d\d)"
+		                 r"(?P<beta>b\d)?(\.exe)?", rar_sfx_file)
 		if match:
 			self.date, self.major, self.minor, self.beta = match.group(
 				"date", "major", "minor", "beta")
@@ -2119,7 +2119,7 @@ def get_set(srr_rar_block):
 	This function tries to pick the basename of such a set.
 	"""
 	n = srr_rar_block.file_name[:-4]
-	match = re.match("(.*)\.part\d*$", n, re.I)
+	match = re.match(r"(.*)\.part\d*$", n, re.I)
 	if match:
 		return match.group(1)
 	else:

--- a/rescene/test/test_utility.py
+++ b/rescene/test/test_utility.py
@@ -250,7 +250,7 @@ class TestUtility(unittest.TestCase):
 
 	def test_is_good(self):
 		self.assertTrue(is_good_srr("good- #@&$§£~(){}[]!çéè"))
-		for char in """\:*?"<>|""":
+		for char in r"""\:*?"<>|""":
 			self.assertFalse(is_good_srr("not" + char + "good"))
 
 	def test_first_rars(self):

--- a/scripts/group_series.py
+++ b/scripts/group_series.py
@@ -41,9 +41,9 @@ def main(options, args):
 
             # try to group the releases together
             for release in rellist:
-                m = re.match("(.*)S\d+E\d+.*", release, re.IGNORECASE)
+                m = re.match(r"(.*)S\d+E\d+.*", release, re.IGNORECASE)
                 if not m:
-                    m = re.match("(.*)\d+x\d+.*", release, re.IGNORECASE)
+                    m = re.match(r"(.*)\d+x\d+.*", release, re.IGNORECASE)
                 if m:
                     # don't add it to the list if foreign
                     if options.foreign:

--- a/scripts/nzbsrr.py
+++ b/scripts/nzbsrr.py
@@ -161,7 +161,7 @@ def main(options, args):
 
 			# a file with the name 'subs' or 'extras' in it? put it at the end
 			for file in files:
-				if re.match(".*(subs|extras|proof|sample).*", file, re.I):
+				if re.match(r".*(subs|extras|proof|sample).*", file, re.I):
 					files.remove(file)
 					files.append(file)
 					haveSubs.append(release)
@@ -247,14 +247,14 @@ def printList(list):
 def parseSubject(subject):  # [#altbin@EFNet]-[FULL]-[RELNAM
 	exts = "\.(srr|srs|avi|mkv)"
 	# exts = "\.(avi)"
-	patternEfnet = (".*\[(.*EFNet|#a.b.teevee)\]-(?:\[(FULL|PART|Movie-Info.org)\]-)?"
-					"\[?\s?(?P<release>[^\s\[\]]+(?=(\]|\s.*\]|-\s)))"
-					"(\s.*)?\]?-?"
-					".*(&quot;|\")(?P<file>.*" + exts + ")(&quot;|\").*")
-	patternXvid = ("#alt.binaries.movies.xvid: (?P<release>[^\s]+)"
-				   " - (&quot;|\")(?P<file>.*" + exts + ")(&quot;|\").*")
-	patternAbmm = ("#a.b.mm@efnet - req \d+ - (?P<release>[^\s]+)"
-				   " - (&quot;|\")(?P<file>.*" + exts + ")(&quot;|\").*")
+	patternEfnet = (r".*\[(.*EFNet|#a.b.teevee)\]-(?:\[(FULL|PART|Movie-Info.org)\]-)?"
+					r"\[?\s?(?P<release>[^\s\[\]]+(?=(\]|\s.*\]|-\s)))"
+					r"(\s.*)?\]?-?"
+					r".*(&quot;|\")(?P<file>.*" + exts + ")(&quot;|\").*")
+	patternXvid = (r"#alt.binaries.movies.xvid: (?P<release>[^\s]+)"
+				   r" - (&quot;|\")(?P<file>.*" + exts + ")(&quot;|\").*")
+	patternAbmm = (r"#a.b.mm@efnet - req \d+ - (?P<release>[^\s]+)"
+				   r" - (&quot;|\")(?P<file>.*" + exts + ")(&quot;|\").*")
 
 	m = re.match(patternEfnet, subject, re.IGNORECASE)
 	if m:
@@ -301,7 +301,7 @@ def parse_name(subject):
 	else:
 		# "Because the poster used a non-standard subject line, the system was
 		# unable to determine the filename with certainty."
-		match = re.search(".*(\]-| )(?P<filename>.*) [\d/\(\)]+", subject)
+		match = re.search(r".*(\]-| )(?P<filename>.*) [\d/\(\)]+", subject)
 		if match:
 			return match.group("filename")
 		else:

--- a/scripts/screenshotcomparison.py
+++ b/scripts/screenshotcomparison.py
@@ -81,7 +81,7 @@ def get_pngs_from_page(soup):
 	return reversed(result)
 	
 def grab_id(url):
-	match = re.match(".*\.com\/comparison\/(\d+)\/.*", url)
+	match = re.match(r".*\.com\/comparison\/(\d+)\/.*", url)
 	if match:
 		return match.group(1)
 	return False

--- a/scripts/tvmove.py
+++ b/scripts/tvmove.py
@@ -164,8 +164,8 @@ def get_key(name):
     # test for the TOPAZ file format
     file_match = re.match(patternFile, name)
 
-    subpack_match = re.search("subpack", name, re.IGNORECASE)
-    extras_match = re.search("extras", name, re.IGNORECASE)
+    subpack_match = re.search(r"subpack", name, re.IGNORECASE)
+    extras_match = re.search(r"extras", name, re.IGNORECASE)
     match = False
 
     if regular_match:
@@ -219,13 +219,13 @@ def check_for_subdir(file):
 
     # does it needs to be moved to a Sample/Subs dir?
     if options.samples_subs:
-        if re.search("sample", file, re.IGNORECASE):
+        if re.search(r"sample", file, re.IGNORECASE):
             extra_subdir = "Sample"
-        elif re.search("subs|vobsub", file, re.IGNORECASE):
+        elif re.search(r"subs|vobsub", file, re.IGNORECASE):
             extra_subdir = "Subs"
 
     if options.proofs:
-        if re.search("proof.*.jpg", file, re.IGNORECASE):
+        if re.search(r"proof.*.jpg", file, re.IGNORECASE):
             extra_subdir = "Proof"
 
     if options.verbose > 1 and extra_subdir != "":

--- a/test_files/media/README.md
+++ b/test_files/media/README.md
@@ -1,0 +1,1 @@
+Download http://www.opensubtitles.org/addons/avi/breakdance.avi and place here

--- a/usenet/nzb_age.py
+++ b/usenet/nzb_age.py
@@ -40,7 +40,7 @@ def main(options, args):
 		# not parsing the whole file, just what we need
 		with open(os.path.join(process_dir, nzbfile), "r") as file:
 			for line in file.readlines():
-				match = re.match(".* date=\"(\d+)\".*", line)
+				match = re.match(r".* date=\"(\d+)\".*", line)
 				if match:
 					date = datetime.datetime.fromtimestamp(int(match.group(1)))
 					break

--- a/usenet/nzb_split.py
+++ b/usenet/nzb_split.py
@@ -236,9 +236,9 @@ def grab_base_name(filename):
 	for suffix in suf:
 		filename = filename.replace(suffix, "")
 	filename = filename.strip("_-")
-	m = re.match("(.*?)(.part\d\d\d?.rar|.par2|.(r|s)\d\d|.sfv|.srr|.srs|"
-				".vob|.mkv|.avi|.mp4|.wmv|.vol\d.*|\.rar|.nfo|.nzb|.jpg|.png|"
-				".\d\d\d)$", filename, re.I)
+	m = re.match(r"(.*?)(.part\d\d\d?.rar|.par2|.(r|s)\d\d|.sfv|.srr|.srs|"
+				r".vob|.mkv|.avi|.mp4|.wmv|.vol\d.*|\.rar|.nfo|.nzb|.jpg|.png|"
+				r".\d\d\d)$", filename, re.I)
 	return m.group(1)
 
 def longest_name(subject, file_name):

--- a/usenet/nzb_utils.py
+++ b/usenet/nzb_utils.py
@@ -80,7 +80,7 @@ def parse_name(subject):
 	else:
 		# "Because the poster used a non-standard subject line, the system was
 		# unable to determine the filename with certainty."
-		match = re.search(".*(\]-| )(?P<filename>.*) [\d/\(\)]+", subject)
+		match = re.search(r".*(\]-| )(?P<filename>.*) [\d/\(\)]+", subject)
 		if match:
 			return match.group("filename")
 		else:

--- a/usenet/srr_usenet.py
+++ b/usenet/srr_usenet.py
@@ -1157,14 +1157,14 @@ def create_srr(nzb_path, options):
 			raise IncompleteNzb("Incomplete RAR file found: %s" % nfile.name)
 
 		# we won't do known repacks either
-		if (re.match("ich\d+.part\d+.rar", nfile.name, re.I) or
-			re.match("zed\d+.part\d+.rar", nfile.name, re.I) or
+		if (re.match(r"ich\d+.part\d+.rar", nfile.name, re.I) or
+			re.match(r"zed\d+.part\d+.rar", nfile.name, re.I) or
 			"kere.ws" in nfile.name):
 			raise Repack("Repack detected: %s" % nfile.name)
 
 		# fail if kere.ws rename is detected
 		if (nfile.name[-4:].lower() == ".rar" and len(nfile.name) == 20 + 4
-		and re.match("^[a-zA-Z0-9]{20}$", nfile.name[:-4])):
+		and re.match(r"^[a-zA-Z0-9]{20}$", nfile.name[:-4])):
 			# these posts don't always have SFVs
 			raise Repack("kere.ws repack detected: %s" % nfile.name)
 
@@ -1197,7 +1197,7 @@ def create_srr(nzb_path, options):
 	assert sfvs == sorted(sfvs)
 	for sfile in sfvs:
 		# SFVs we want to have at the end of the SRR
-		if re.match(".*(extras|proof|sample|subpack).*", sfile.name, re.I):
+		if re.match(r".*(extras|proof|sample|subpack).*", sfile.name, re.I):
 			sfvs.remove(sfile)
 			sfvs.append(sfile)
 


### PR DESCRIPTION
* Strings containing escapes are now prefixed with `r` to mark them as  raw strings: https://docs.python.org/3/whatsnew/3.12.html#other-language-changes
> A backslash-character pair that is not a valid escape sequence now generates a SyntaxWarning, instead of DeprecationWarning. 
> For example, re.compile("\d+\.\d+") now emits a SyntaxWarning ("\d" is an invalid escape sequence, use raw strings for regular expression: re.compile(r"\d+\.\d+")).
> In a future Python version, SyntaxError will eventually be raised, instead of SyntaxWarning. (Contributed by Victor Stinner in gh-98401.)
  * https://docs.python.org/3.12/reference/lexical_analysis.html#escape-sequences

* `locale.format` was removed in Python 3.12 and is replaced by `locale.format_string` and is equivalent since Python 3.7
