### PR TITLE
Force rar4 format on compressed

### DIFF
--- a/rescene/main.py
+++ b/rescene/main.py
@@ -1987,7 +1987,7 @@ class RarArguments(object):
 	def set_rar2_flags(self, rar2_detected):
 		self.old_naming_flag = "" if rar2_detected else "-vn"
 
-	def set_rar5_flags(self, rar5_detected):
+	def set_rar4_flags(self, rar5_detected):
 		self.force_rar4_flag = "-ma4" if rar5_detected else ""
 	
 def compressed_rar_file_factory(block, blocks, src,
@@ -2288,7 +2288,7 @@ class CompressedRarFile(io.IOBase):
 			# we assume that newer versions always compress better
 			rarexe = repository.get_most_recent_version()
 			args.set_rar2_flags(re.search(r'_rar2', rarexe.path()) is not None)
-			args.set_rar5_flags(re.search(r'_rar[5-9]', rarexe.path()) is not None)
+			args.set_rar4_flags(re.search(r'_rar[5-9]', rarexe.path()) is not None)
 			
 			window_size = block.get_dict_size()
 			amount = 0
@@ -2417,7 +2417,7 @@ class CompressedRarFile(io.IOBase):
 		for rar in repository.get_rar_executables(self.get_most_recent_date()):
 			_fire(MsgCode.MSG, message="Trying %s." % rar)
 			args.set_rar2_flags(re.search(r'_rar2', rar.path()) is not None)
-			args.set_rar5_flags(re.search(r'_rar[5-9]', rarexe.path()) is not None)
+			args.set_rar4_flags(re.search(r'_rar[5-9]', rarexe.path()) is not None)
 			found = False
 			if rar.supports_setting_threads():
 				while args.increase_thread_count(rar):

--- a/rescene/main.py
+++ b/rescene/main.py
@@ -1875,6 +1875,7 @@ class RarArguments(object):
 		self.threads = ""
 		self.split = ""
 		self.old_naming_flag = "-vn"
+		self.force_rar4_flag = ""
 		
 	def increase_thread_count(self, rarbin):
 		# <threads> parameter can take values from 0 to 16.
@@ -1927,6 +1928,7 @@ class RarArguments(object):
 			["a", self.compr_level, self.dict_size, 
 			self.solid, self.solid_namesort, self.threads,
 			self.old_naming_flag, # old style volume naming scheme
+			self.force_rar4_flag,
 			"-o+", # Overwrite all
 			"-ep", # Exclude paths from names.
 			"-idcd", # Disable messages: copyright string, "Done" string
@@ -1984,6 +1986,9 @@ class RarArguments(object):
 
 	def set_rar2_flags(self, rar2_detected):
 		self.old_naming_flag = "" if rar2_detected else "-vn"
+
+	def set_rar5_flags(self, rar5_detected):
+		self.force_rar4_flag = "-ma4" if rar5_detected else ""
 	
 def compressed_rar_file_factory(block, blocks, src,
 	                            in_folder, hints, auto_locate_renamed):
@@ -2283,6 +2288,7 @@ class CompressedRarFile(io.IOBase):
 			# we assume that newer versions always compress better
 			rarexe = repository.get_most_recent_version()
 			args.set_rar2_flags(re.search(r'_rar2', rarexe.path()) is not None)
+			args.set_rar5_flags(re.search(r'_rar[5-9]', rarexe.path()) is not None)
 			
 			window_size = block.get_dict_size()
 			amount = 0
@@ -2411,6 +2417,7 @@ class CompressedRarFile(io.IOBase):
 		for rar in repository.get_rar_executables(self.get_most_recent_date()):
 			_fire(MsgCode.MSG, message="Trying %s." % rar)
 			args.set_rar2_flags(re.search(r'_rar2', rar.path()) is not None)
+			args.set_rar5_flags(re.search(r'_rar[5-9]', rarexe.path()) is not None)
 			found = False
 			if rar.supports_setting_threads():
 				while args.increase_thread_count(rar):


### PR DESCRIPTION
Set flag/option `-ma4` when trying to recreate compressed archives with rar versions 5.x and above. This will allow using versions 5.50+ to recreate compressed archives.