### PR TITLE
Python3.13 workarounds

### DIFF
--- a/bin/pyrescene.py
+++ b/bin/pyrescene.py
@@ -52,7 +52,13 @@ import time
 import logging
 import itertools
 import struct
-import imghdr
+
+try:
+	import imghdr
+except ModuleNotFoundError:
+	print("imghdr is not available in Python 3.12+")
+	print("Run: pip install standard-imghdr==3.13 to fix this")
+	exit(1)
 
 try:
 	import win32api

--- a/rescene/main.py
+++ b/rescene/main.py
@@ -41,13 +41,11 @@ import zlib
 import re
 
 import hashlib
-import nntplib
 import collections
 
 import time
 import shutil
 import subprocess
-import multiprocessing
 
 import rescene
 from rescene.rar import (BlockType, RarReader,
@@ -644,6 +642,13 @@ def create_srr_single_volume(srr_name, infile, tmp_srr_name=None):
 def _rarreader_usenet(rarfile, read_retries=7):
 	"""Tries redownloading data read_retries times if it fails.
 	Regular RarReader, but handles Usenet exceptions and retries."""
+	try:
+		import nntplib
+	except:
+		print("nntplib is not available in Python 3.12+")
+		print("Run: pip install standard-nntplib==3.13 to fix this")
+		exit(1)
+
 	rr = RarReader(rarfile)
 	try:
 		return rr.read_all()


### PR DESCRIPTION
Not the greatest fix, but it beats shipping the libs and dealing with licensing.

imghdr would be fine, nntplib is probably not that used to hiding that message to when usenet related functions are called.

Related to: https://github.com/srrDB/pyrescene/issues/8
Related to: https://github.com/srrDB/pyrescene/issues/12
Closes: #25 