### PR TITLE
fix[resample/main]: .flac rebuild block type check breaks as fr.block_type is not bytes

### DIFF
--- a/resample/main.py
+++ b/resample/main.py
@@ -3769,7 +3769,7 @@ def flac_rebuild_sample(self, srs_data, tracks, attachments, srs, out_file):
 				flac.write(b"fLaC")
 				crc = crc32(b"fLaC", crc)
 				fr.skip_contents()
-			elif (fr.block_type in bytearray(b"stu") and
+			elif (fr.block_type in (ord('s'), ord('t'), ord('u')) and
 					srs_flac_blocks <= 3):
 				srs_flac_blocks += 1
 				fr.skip_contents()


### PR DESCRIPTION
When going through some .flac releases with `retag`, I encountered an error with `resample`:
```
D:\!move\srrGUI>retag.py ".\_srr\_done\Fatboy_Slim-The_Rockafeller_Skank-CDM-FLAC-1998-c05_INT.srr" -y -i ".\_in\flac\Fatboy_Slim-The_Rockafeller_Skank-CDM-FLAC-1998-c05_INT" -o ".\_out\FLAC\Fatboy_Slim-The_Rockafeller_Skank-CDM-FLAC-1998-c05_INT"
Extracting 00-fatboy_slim-the_rockafeller_skank-cdm-flac-1998.nfo
Extracting 00-fatboy_slim-the_rockafeller_skank-cdm-flac-1998-proof.jpg
Extracting 00-fatboy_slim-the_rockafeller_skank-cdm-flac-1998.m3u
Extracting 00-fatboy_slim-the_rockafeller_skank-cdm-flac-1998.sfv
Using 01-fatboy_slim-the_rockafeller_skank_(short_edit).srs
Fixing 01-fatboy_slim-the_rockafeller_skank_(short_edit).flac
From .\_in\flac\Fatboy_Slim-The_Rockafeller_Skank-CDM-FLAC-1998-c05_INT\01-fatboy_slim-the_rockafeller_skank_(short_edit).flac
SRS Load Complete...          Elapsed Time: 0.00s
Track Location Complete...    Elapsed Time: 0.00s
Track Extraction Complete...  Elapsed Time: 0.04s
Traceback (most recent call last):
  File "C:\Program Files\Python313\Lib\site-packages\resample\srs.py", line 514, in main
    sfile = sample.rebuild_sample(srs_data, tracks, attachments,
                                                          srs, out_file)
  File "C:\Program Files\Python313\Lib\site-packages\resample\main.py", line 668, in rebuild_sample
    return flac_rebuild_sample(self, *args, **kwargs)
  File "C:\Program Files\Python313\Lib\site-packages\resample\main.py", line 3772, in flac_rebuild_sample
    elif (fr.block_type in bytearray(b"stu") and
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: a bytes-like object is required, not 'str'
Unexpected Error:
a bytes-like object is required, not 'str'
```

`fr.block_type` as in resample/flac.py is usually a `int` as it's just unpacked from it's byte form; but is also `str` when dealing with the flac header "`fLaC`"; but files improperly tagged with ID3 tagging has block types "`ID3`" and "`TAG`".

Strings can't be compared to `bytes` in a `bytearray`; instead check against the `ord`inal values of "`s`", "`t`" and "`u`", which can be compared against `bytes`, `str`ings and `int`egers. This allows the release to be rebuilt.

The release used, `Fatboy_Slim-The_Rockafeller_Skank-CDM-FLAC-1998-c05_INT`, uses ID3 tagging which introduces `block_type`s  "`ID3`" and "`TAG`". The "`fLaC`" type is checked against explicitly; the error I'm seeing is after the flac header check fails over into the `elif`.
Adding a `print(fr.block_type, type(fr.block_type))` to the `fr.read()` `while` loop shows this:
```
Using 04-fatboy_slim-tweakers_delight.srs
Fixing 04-fatboy_slim-tweakers_delight.flac
From .\_in\flac\Fatboy_Slim-The_Rockafeller_Skank-CDM-FLAC-1998-c05_INT\04-fatboy_slim-tweakers_delight.flac
SRS Load Complete...          Elapsed Time: 0.00s
Track Location Complete...    Elapsed Time: 0.00s
Track Extraction Complete...  Elapsed Time: 0.03s
ID3 <class 'str'>
fLaC <class 'str'>
115 <class 'int'>
116 <class 'int'>
117 <class 'int'>
0 <class 'int'>
3 <class 'int'>
4 <class 'int'>
129 <class 'int'>
TAG <class 'str'>
```

-= Links for testing =-
The SRR used: <https://www.srrdb.com/download/srr/Fatboy_Slim-The_Rockafeller_Skank-CDM-FLAC-1998-c05_INT>
The release itself: <https://tanizaki.angelicdust.net/Fatboy_Slim-The_Rockafeller_Skank-CDM-FLAC-1998-c05_INT.zip>